### PR TITLE
fix: now loading darkbox instead of gruvbox

### DIFF
--- a/colors/darkbox.lua
+++ b/colors/darkbox.lua
@@ -1,1 +1,1 @@
-require("gruvbox").load()
+require("darkbox").load()


### PR DESCRIPTION
I got an error while loading the colorscheme:

```
Error while calling lua chunk: ...p/.local/share/nvim/lazy/darkbox.nvim/colors/darkbox.lua:1: module 'gruvbox' not found:
	no field package.preload['gruvbox']
```

Turns out that `colors/darkbox.lua` was still loading `gruvbox` instead of `darkbox`.


This is now fixed.